### PR TITLE
Better sorting (most recent instead of oldest) and some changes to my listing

### DIFF
--- a/_posts/2015-05-02-rubycastsio.html
+++ b/_posts/2015-05-02-rubycastsio.html
@@ -2,10 +2,10 @@
 layout: default
 title:  Rubycasts
 link: https://www.rubycasts.io
-categories: [ruby, rails]
+categories: [ruby, rails, coffeescript]
 level: [beginning, intermediate, advanced]
-instruction: [video]
-price: [free/subscription]
+instruction: [video, online]
+price: [free, subscription]
 image: https://s3-us-west-2.amazonaws.com/rubycastio-assets-production/images/homepage-screenshot-sm.png
 ---
 

--- a/_posts/2015-05-02-rubycastsio.html
+++ b/_posts/2015-05-02-rubycastsio.html
@@ -1,16 +1,15 @@
 ---
 layout: default
-title:  RUBYCASTS.IO
+title:  Rubycasts
 link: https://www.rubycasts.io
 categories: [ruby, rails]
 level: [beginning, intermediate, advanced]
 instruction: [video]
 price: [free/subscription]
-image: https://www.rubycasts.io/assets/rubycasts-biglogo-b1087204e5a15181b13bd4f8e68abc58.png
+image: https://s3-us-west-2.amazonaws.com/rubycastio-assets-production/images/homepage-screenshot-sm.png
 ---
-
 
 Rubycasts is a weekly screencast series where the focus is on the full Ruby
 development stack. Become a better Rails developer, become a better Ruby
-developer.
+developer, make more money at your next job!
 

--- a/index.html
+++ b/index.html
@@ -54,7 +54,6 @@ title: iwanttolearnruby
 <script type="text/javascript">
   $(function(){
     $(".links li").tsort();
-    $(".post").tsort();
 
     $(".links a").click(function(e){
       $('.links a').removeClass('current');


### PR DESCRIPTION
I didn't want to have to put in future pull requests to update the 'screenshot' so I changed the link.

Also, there was a javascript sort that was defaulting to the oldest listings with no images. I think the new sorting looks much better, and as even newer resources get on here my listing will move down like it should.

Please merge if you find these changes pleasing. Thanks!
